### PR TITLE
Add BTC price alert bot

### DIFF
--- a/btc_bot.py
+++ b/btc_bot.py
@@ -1,0 +1,22 @@
+import time
+import requests
+
+
+def get_btc_price():
+    url = 'https://api.coingecko.com/api/v3/simple/price'
+    params = {'ids': 'bitcoin', 'vs_currencies': 'usd'}
+    response = requests.get(url, params=params)
+    response.raise_for_status()
+    return response.json()['bitcoin']['usd']
+
+
+while True:
+    price = get_btc_price()
+    print(f"Current BTC Price: ${price}")
+
+    if price > 70000:
+        print("🚨 Bitcoin is ABOVE $70,000!")
+    elif price < 60000:
+        print("⚠️ Bitcoin is BELOW $60,000!")
+
+    time.sleep(300)


### PR DESCRIPTION
## Summary
- add a Python script `btc_bot.py` to poll the CoinGecko API every five minutes and alert when price goes above $70k or below $60k

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68452e917258832985b91d43c59aef9b